### PR TITLE
Enable code coverage for the tidycat/user-interface repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -15,3 +15,4 @@
 /libpeerconnection.log
 npm-debug.log
 testem.log
+lcov.dat

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,9 @@ install:
 script:
   - "make test"
 
+after_success:
+  - 'cat lcov.dat | `npm bin`/coveralls'
+
 notifications:
   email: false
   irc:

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,7 @@ clean-all: clean  ## Burn everything to the ground
 	rm -rf libpeerconnection.log
 	rm -rf npm-debug.log
 	rm -rf testem.log
+	rm -f lcov.dat
 
 .PHONY: install
 install:  ## Install project dependencies

--- a/bower.json
+++ b/bower.json
@@ -6,5 +6,8 @@
     "ember-cli-test-loader": "0.2.2",
     "ember-qunit-notifications": "0.1.0",
     "bootstrap-sass": "^3.3.6"
+  },
+  "devDependencies": {
+    "blanket": "5e94fc30f2e694bb5c3718ddcbf60d467f4b4d26"
   }
 }

--- a/package.json
+++ b/package.json
@@ -21,10 +21,12 @@
   "devDependencies": {
     "babel-eslint": "^5.0.0",
     "broccoli-asset-rev": "^2.2.0",
+    "coveralls": "^2.11.8",
     "ember-ajax": "0.7.1",
     "ember-cli": "2.4.2",
     "ember-cli-app-version": "^1.0.0",
     "ember-cli-babel": "^5.1.5",
+    "ember-cli-blanket": "0.9.1",
     "ember-cli-bootstrap-sassy": "0.5.3",
     "ember-cli-dependency-checker": "^1.2.0",
     "ember-cli-htmlbars": "^1.0.1",

--- a/testem.js
+++ b/testem.js
@@ -1,7 +1,7 @@
 /*jshint node:true*/
 module.exports = {
   "framework": "qunit",
-  "test_page": "tests/index.html?hidepassed",
+  "test_page": "tests/index.html?hidepassed&coverage=true",
   "disable_watching": true,
   "launch_in_ci": [
     "PhantomJS"

--- a/tests/blanket-options.js
+++ b/tests/blanket-options.js
@@ -1,0 +1,34 @@
+/* globals blanket, module */
+
+var options = {
+  modulePrefix: 'tidycat-ui',
+  filter: '//.*tidycat-ui/.*/',
+  antifilter: '//.*(tests|template).*/',
+  loaderExclusions: [],
+  enableCoverage: true,
+  branchTracking: true,
+  cliOptions: {
+    reporters: ['lcov'],
+    autostart: true,
+    lcovOptions: {
+      // automatically skip missing files, relative to project's root dir
+      excludeMissingFiles: true, // default false
+
+      // provide a function to rename es6 modules to a file path
+      renamer: function(moduleName) {
+        // return a falsy value to skip given module
+        if (moduleName === 'unwanted') {
+          return;
+        }
+
+        var expression = /^tidycat-ui/;
+        return moduleName.replace(expression, 'app') + '.js';
+      }
+    }
+  }
+};
+if (typeof exports === 'undefined') {
+  blanket.options(options);
+} else {
+  module.exports = options;
+}

--- a/tests/index.html
+++ b/tests/index.html
@@ -13,6 +13,7 @@
     <link rel="stylesheet" href="assets/vendor.css">
     <link rel="stylesheet" href="assets/tidycat-ui.css">
     <link rel="stylesheet" href="assets/test-support.css">
+    <style>#blanket-main { position: relative; z-index: 99999; }</style>
 
     {{content-for "head-footer"}}
     {{content-for "test-head-footer"}}
@@ -25,6 +26,8 @@
     <script src="assets/vendor.js"></script>
     <script src="assets/test-support.js"></script>
     <script src="assets/tidycat-ui.js"></script>
+    <script src="assets/blanket-options.js"></script>
+    <script src="assets/blanket-loader.js"></script>
     <script src="assets/tests.js"></script>
     <script src="assets/test-loader.js"></script>
 


### PR DESCRIPTION
Essentially uses a combination of ember-cli-blanket + coveralls + duct tape.
